### PR TITLE
chore: environment configuration

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,14 @@
+server.port = 8080
+
+spring.datasource.url=jdbc:postgresql://localhost:5432/argos_dev_db
+spring.datasource.username=user
+spring.datasource.password=password
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+
+spring.jpa.properties.hibernate.boot.allow_jdbc_metadata_access=false
+
+spring.jpa.hibernate.ddl-auto=update
+spring.sql.init.mode=never

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,14 @@
+server.port = 8082
+
+spring.datasource.url=jdbc:postgresql://localhost:5432/argos_prod_db
+spring.datasource.username=user
+spring.datasource.password=password
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+
+spring.jpa.properties.hibernate.boot.allow_jdbc_metadata_access=false
+
+spring.jpa.hibernate.ddl-auto=update
+spring.sql.init.mode=never

--- a/src/main/resources/application-stage.properties
+++ b/src/main/resources/application-stage.properties
@@ -1,0 +1,14 @@
+server.port = 8081
+
+spring.datasource.url=jdbc:postgresql://localhost:5432/argos_stage_db
+spring.datasource.username=user
+spring.datasource.password=password
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+
+spring.jpa.properties.hibernate.boot.allow_jdbc_metadata_access=false
+
+spring.jpa.hibernate.ddl-auto=update
+spring.sql.init.mode=never

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 spring.application.name=argos
 
+spring.profiles.active=dev


### PR DESCRIPTION
<!--- Provide a general summary of the pull request in the Title above -->
<!-- Please complete this template before creating the pull request. -->

<!-- Pull Request Template -->
#### Resolved task/US: Configure environment profiles
* * * *

## What's in this pull request?
<!-- Please include a summary of the change and which US or Task is fixed. -->
<!-- Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This PR introduces configuration changes to support multiple environment profiles (**dev**, **stage**, and **prod**) in the Spring Boot application. 

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Build Configuration Change
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->
3 different environments were created where each one has its database (not set it yet due to the project doesn't contain the required dependencies) and its port set it.

To view the different environment, just run the application class and it will start on the default one, which is dev environment according the properties file set it for now.

To change between the environments, in the main properties file change the content after the equal, like below:
Running on port 8080:
```
spring.profiles.active=dev
```
Running on port 8081:
```
spring.profiles.active=stage
```
Running on port 8082:
```
spring.profiles.active=prod
```

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings